### PR TITLE
Use passphrase for sensitive access

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,10 +16,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.22'
+        go-version: '1.23'
 
     - name: Build
       run: go build -v .
 
     - name: Test
-      run: go test -v ./internal/config ./internal/passwords ./internal/database
+      run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 go.work
 
 passfish
+
+.DS_Store

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -5,7 +5,6 @@ import (
   "os"
 	"log"
 	"passfish/internal/clipboard"
-	"passfish/internal/config"
 	"passfish/internal/database"
 	"passfish/internal/models"
 	"passfish/internal/passwords"
@@ -17,11 +16,6 @@ var addCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Add a login",
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg, err := config.New(cfgFile)
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		db, err := database.New(cfg.DbPath)
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -25,15 +25,15 @@ var addCmd = &cobra.Command{
     // Lookup passphrase first
     passphrase, found := os.LookupEnv("PASSFISH_PASSPHRASE")
     if !found {
-      passphrase, err = readStringInput("Enter the passphrase: ")
+      passphrase, err = readPasswordInput("Enter the passphrase: ")
       if err != nil {
         log.Fatal(err)
       }
     }
 
-    // TODO: verify_passphrase
-
-		db.CreateCredentialsTable()
+    if !db.VerifyPassphrase(passphrase) {
+      log.Fatal("❌ Incorrect passphrase.")
+    }
 
 		login, err := cmd.Flags().GetString("login")
 		if err != nil {
@@ -57,11 +57,12 @@ var addCmd = &cobra.Command{
 		}
 		for username == "" {
 			username, err = readStringInput(fmt.Sprintf("Enter a username for %s: ", login))
-			if username == "" {
-				log.Print("❌ Username cannot be empty.")
-			}
 			if err != nil {
 				log.Fatal(err)
+			}
+
+			if username == "" {
+				log.Print("❌ Username cannot be empty.")
 			}
 		}
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -53,13 +53,15 @@ var goCmd = &cobra.Command{
 
       passphrase, found := os.LookupEnv("PASSFISH_PASSPHRASE")
       if !found {
-        passphrase, err = readStringInput("Enter the passphrase: ")
+        passphrase, err = readPasswordInput("Enter the passphrase: ")
         if err != nil {
           log.Fatal(err)
         }
       }
 
-      // TODO: verify_passphrase
+      if !db.VerifyPassphrase(passphrase) {
+        log.Fatal("❌ Incorrect passphrase!")
+      }
 
       clipboard.Copy(cred.DecryptPassword(passphrase))
       fmt.Printf("Username %s\n", cred.Base.Username)

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -10,6 +10,7 @@ import (
 	"passfish/internal/models"
 	"passfish/internal/stringutils"
 	"strings"
+  "os"
 
 	"github.com/spf13/cobra"
 )
@@ -53,13 +54,24 @@ var goCmd = &cobra.Command{
 
 				// Reset to trigger user prompt again
 				login = ""
-			} else {
-				fmt.Printf("Username %s\n", cred.Base.Username)
-				fmt.Printf("Copied 🔑\n")
-				clipboard.Copy(cred.DecryptPassword(cfg.DbPassphrase))
-				db.MarkAccessed(login)
-				break
+        continue
 			}
+
+      passphrase, found := os.LookupEnv("PASSFISH_PASSPHRASE")
+      if !found {
+        passphrase, err = readStringInput("Enter the passphrase: ")
+        if err != nil {
+          log.Fatal(err)
+        }
+      }
+
+      // TODO: verify_passphrase
+
+      clipboard.Copy(cred.DecryptPassword(passphrase))
+      fmt.Printf("Username %s\n", cred.Base.Username)
+      fmt.Printf("Copied 🔑\n")
+      db.MarkAccessed(login)
+      break
 		}
 	},
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"passfish/internal/clipboard"
-	"passfish/internal/config"
 	"passfish/internal/database"
 	"passfish/internal/models"
 	"passfish/internal/stringutils"
@@ -19,11 +18,6 @@ var goCmd = &cobra.Command{
 	Use:   "go",
 	Short: "Get a login",
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg, err := config.New(cfgFile)
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		db, err := database.New(cfg.DbPath)
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"passfish/internal/config"
 
 	"github.com/spf13/cobra"
 )
@@ -13,12 +12,6 @@ var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize the password manager",
 	Run: func(cmd *cobra.Command, args []string) {
-		// Check if the configuration file exists.
-		f, err := os.Open(cfgFile)
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer f.Close()
 		if err == nil {
 			fmt.Println("WARNING!!! Configuration file already exists!")
 			var resp string = ""

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
-	"os"
+	"passfish/internal/database"
 
 	"github.com/spf13/cobra"
 )
@@ -12,30 +12,31 @@ var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize the password manager",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err == nil {
-			fmt.Println("WARNING!!! Configuration file already exists!")
-			var resp string = ""
-			for resp == "" {
-				resp, err = readStringInput("Do you want to overwrite the configuration file? (y/n): ")
-				if err != nil {
-					log.Fatal(err)
-				}
-				if resp != "y" && resp != "n" {
-					fmt.Printf("Please try again, \"%v\" is not a valid response.\n", resp)
-					resp = ""
-				}
-			}
+    db, err := database.New(cfg.DbPath)
+    if err != nil {
+      log.Fatal(err)
+    }
+    defer db.Close()
 
-			if resp == "n" {
-				fmt.Println("Exiting...")
-				os.Exit(0)
-			}
-		}
+    // Create tables if they don't exist
+    db.CreateTables()
 
-		// Overwrite the configuration file
-		if err := config.CreateConfigFile(cfgFile); err != nil {
-			log.Fatal(err)
-		}
+    passphrase := db.GetPassphrase()
+    for passphrase == "" {
+      resp, err := readPasswordInput("Insert a passphrase, this should be *extra* secret: ")
+      if err != nil {
+        log.Fatal(err)
+      }
+      if len(resp) < 8 {
+        fmt.Println("Come on... Your passphrase must be at LEAST 8 characters long.")
+        continue
+      }
+
+      passphrase = resp
+      if err = db.SetPassphrase(passphrase); err != nil {
+        log.Fatal(err)
+      }
+    }
 	},
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"log"
-	"passfish/internal/config"
 	"passfish/internal/database"
 	"passfish/internal/models"
 	"passfish/internal/stringutils"
@@ -16,11 +15,6 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Display added logins",
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg, err := config.New(cfgFile)
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		db, err := database.New(cfg.DbPath)
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -21,12 +21,6 @@ var listCmd = &cobra.Command{
 		}
 		defer db.Close()
 
-		// Check if the time_sorted flag is set.
-		time_sorted, err := cmd.Flags().GetBool("time-sorted")
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		titles, err := db.GetTitles()
 		if err != nil {
 			log.Fatal(err)
@@ -40,23 +34,16 @@ var listCmd = &cobra.Command{
 			}
 			creds = append(creds, *cred)
 		}
-		if time_sorted {
-			// Display logins sorted by most recently accessed.
-			fmt.Println("🕰️ Displaying logins sorted by most recently accessed.")
 
-			// Sort creds by their last accessed time.
-			sort.Slice(creds, func(i int, j int) bool {
-				return creds[i].LastAccessed.Compare(creds[j].LastAccessed) > 0
-			})
-		} else {
-			// Display logins sorted by name.
-			fmt.Println("🔤 Displaying logins sorted by name.")
+    // Display logins sorted by most recently accessed.
+    fmt.Println("🕰️ Displaying logins sorted by most recently accessed.")
 
-			// Sort creds by their title.
-			sort.Slice(creds, func(i int, j int) bool {
-				return creds[i].Base.Title < creds[j].Base.Title
-			})
-		}
+    // Sort creds by their last accessed time.
+    sort.Slice(creds, func(i int, j int) bool {
+      return creds[i].LastAccessed.Compare(creds[j].LastAccessed) > 0
+    })
+
+    // Display the logins.
 		for i, cred := range creds {
 			fmt.Printf("%3d | %s | %s | %s\n",
 				i,
@@ -69,6 +56,4 @@ var listCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(listCmd)
-
-	listCmd.Flags().BoolP("time-sorted", "t", false, "sort logins by most recently accessed")
 }

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"passfish/internal/config"
 	"passfish/internal/database"
 	"passfish/internal/models"
 	"passfish/internal/stringutils"
@@ -17,11 +16,6 @@ var removeCmd = &cobra.Command{
 	Use:   "remove",
 	Short: "Remove a login",
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg, err := config.New(cfgFile)
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		db, err := database.New(cfg.DbPath)
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path"
+  "passfish/internal/config"
 
 	"github.com/spf13/cobra"
 )
@@ -21,15 +22,15 @@ var rootCmd = &cobra.Command{
 	Short:   "CLI Password Manager",
 	Version: Version,
 	Run: func(cmd *cobra.Command, args []string) {
-		if config, err := cmd.Flags().GetString("config"); err != nil {
+		if cfg, err := cmd.Flags().GetString("database"); err != nil {
 			log.Fatal(err)
 		} else {
-			fmt.Println("Using config file: ", config)
+			fmt.Println("Using database file: ", cfg)
 		}
 	},
 }
 
-var cfgFile string
+var cfg config.Config = config.Config{}
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
@@ -52,5 +53,19 @@ func init() {
 		log.Fatal(err)
 	}
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", fmt.Sprintf("%s/passfish.yaml", dirname), "config file")
+  var cfgFile string
+	rootCmd.PersistentFlags().StringVar(
+    &cfgFile,                                  // pointer to variable
+    "config",                                 // flag name
+    fmt.Sprintf("%s/passfish.yaml", dirname), // default value
+    "config file",                            // help message
+  )
+
+  tmp, err := config.New(cfgFile)
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  // Set to global config
+  cfg.DbPath = tmp.DbPath
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"passfish/internal/config"
 	"passfish/internal/database"
 	"passfish/internal/stringutils"
 	"strings"
@@ -20,10 +19,6 @@ var searchCmd = &cobra.Command{
 		if len(args) == 0 {
 			log.Println("🔎 No search terms provided.")
 			os.Exit(0)
-		}
-		cfg, err := config.New(cfgFile)
-		if err != nil {
-			log.Fatal(err)
 		}
 
 		db, err := database.New(cfg.DbPath)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,6 @@ import (
 
 type Config struct {
 	DbPath       string `yaml:"dbPath"`
-	DbPassphrase string `yaml:"dbPassphrase"`
 }
 
 type MissingFieldError struct {
@@ -24,11 +23,6 @@ func verifyConfig(cfg *Config) error {
 	if cfg.DbPath == "" {
 		return &MissingFieldError{Field: "dbPath"}
 	}
-
-	if cfg.DbPassphrase == "" {
-		return &MissingFieldError{Field: "dbPassphrase"}
-	}
-
 	return nil
 }
 
@@ -39,7 +33,7 @@ func CreateConfigFile(cfgPath string) error {
 	}
 	defer f.Close()
 
-	if _, err := f.WriteString("dbPath: \ndbPassphrase: "); err != nil {
+	if _, err := f.WriteString("dbPath: shhh.db"); err != nil {
 		return err
 	}
 	fmt.Printf("Configuration file created successfully at %v! Populate fields before using passfish!", cfgPath)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -23,9 +23,8 @@ func TestNewConfig(t *testing.T) {
 	}
 
 	dbPath := path.Join(dir, "test_db.sql")
-	passphrase := "secret"
 	// Write the YAML content to the file
-	_, err = file.WriteString(fmt.Sprintf("\ndbPath: %s\ndbPassphrase: %s\n", dbPath, passphrase))
+	_, err = file.WriteString(fmt.Sprintf("\ndbPath: %s\n", dbPath))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,9 +39,6 @@ func TestNewConfig(t *testing.T) {
 	// Check the values of the Config struct
 	if cfg.DbPath != dbPath {
 		t.Errorf("Expected \"DbPath\" to be %s, got %s", dbPath, cfg.DbPath)
-	}
-	if cfg.DbPassphrase != passphrase {
-		t.Errorf("Expected \"DbPassphrase\" to be %s, got %s", passphrase, cfg.DbPassphrase)
 	}
 }
 
@@ -59,13 +55,6 @@ func TestNewConfigNoDbPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	passphrase := "secret"
-	// Write the YAML content to the file
-	_, err = file.WriteString(fmt.Sprintf("\ndbPassphrase: %s\n", passphrase))
-	if err != nil {
-		t.Fatal(err)
-	}
 	file.Close()
 
 	cfg, err := config.New(file.Name())
@@ -79,37 +68,6 @@ func TestNewConfigNoDbPath(t *testing.T) {
 
 func TestNewConfigFileNotExist(t *testing.T) {
 	_, err := config.New("nonexistent.yaml")
-	if err == nil {
-		t.Error("Expected an error, got nil")
-	}
-}
-
-func TestNewConfigNoDbPassphrase(t *testing.T) {
-	// Create a temporary directory
-	dir, err := os.MkdirTemp(".", "t_*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	// Create a temporary file
-	file, err := os.Create(path.Join(dir, "config.yaml"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	dbPath := path.Join(dir, "test_db.sql")
-	// Write the YAML content to the file
-	_, err = file.WriteString(fmt.Sprintf("\ndbPath: %s\n", dbPath))
-	if err != nil {
-		t.Fatal(err)
-	}
-	file.Close()
-
-	cfg, err := config.New(file.Name())
-	if cfg != nil {
-		t.Errorf("Expected nil, got %v", cfg)
-	}
 	if err == nil {
 		t.Error("Expected an error, got nil")
 	}

--- a/internal/database/credentials.go
+++ b/internal/database/credentials.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Creates the credentials table if it does not exist.
-func (db *Db) CreateCredentialsTable() error {
+func (db *Db) createCredentialsTable() error {
 	sqlStmt := `
 	create table if not exists credentials (
 		title text not null primary key,

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -29,3 +29,15 @@ func New(dbPath string) (*Db, error) {
 func (db *Db) Close() {
 	db.Conn.Close()
 }
+
+func (db *Db) CreateTables() error {
+  if err := db.createCredentialsTable(); err != nil {
+    return err
+  }
+
+  if err := db.createPassphraseTable(); err != nil {
+    return err
+  }
+
+  return nil
+}

--- a/internal/database/passphrase.go
+++ b/internal/database/passphrase.go
@@ -1,0 +1,65 @@
+package database
+
+import (
+  "errors"
+  "passfish/internal/passwords"
+)
+
+func (db *Db) createPassphraseTable() error {
+  sqlStmt := `
+  create table if not exists passphrase (
+    passphrase blob not null
+  );
+  `
+  _, err := db.Conn.Exec(sqlStmt)
+  return err
+}
+
+func (db *Db) SetPassphrase(passphrase string) error {
+  // Encrypt the passphrase and insert it into the database.
+  if db.GetPassphrase() != "" {
+    return errors.New("a passphrase already exists in the database")
+  }
+
+  sqlStmt := `
+  insert into passphrase (passphrase) values (?);
+  `
+
+  e_passphrase := passwords.Encrypt(passphrase, passphrase)
+  _, err := db.Conn.Exec(sqlStmt, e_passphrase)
+  return err
+}
+
+func (db *Db) VerifyPassphrase(passphrase string) bool {
+  // Check if the argument passphrase correctly decrypts the passphrase stored
+  // in the database.
+  if db.GetPassphrase() == "" {
+    return false
+  }
+
+  // If the passphrase does not decrypt the stored passphrase, return false.
+  if passwords.Decrypt(db.GetPassphrase(), passphrase) != passphrase {
+    return false
+  }
+
+  return true
+}
+
+func (db *Db) GetPassphrase() string {
+  sqlStmt := `
+  select passphrase from passphrase;
+  `
+  row := db.Conn.QueryRow(sqlStmt)
+
+  var e_passphrase string
+  row.Scan(&e_passphrase)
+  return e_passphrase
+}
+
+func (db *Db) DeletePassphrase() error {
+  sqlStmt := `
+  delete from passphrase;
+  `
+  _, err := db.Conn.Exec(sqlStmt)
+  return err
+}


### PR DESCRIPTION
- **wip: Change how passphrase is managed**
- **Ignore macOS file**
- **Remove config instantiation in each cmd**
- **Input passphrase for sensitive access**
- **Clean up list usability**
- **Fix database unit tests**
